### PR TITLE
Some slight improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ $ npm install mdjson
 const mdjson = require('mdjson')
 
 mdjson(`
+  This part (before any headers) is ignored. Feel free
+  to use this section for commentary on the file's purpose,
+  if you wish.
+
   ## my heading
   oh wow, amazing
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const assert = require('assert')
 const marked = require('marked')
 const clone = require('clone')
-const lexer = new marked.Lexer()
 
 module.exports = toObj
 
@@ -10,6 +9,7 @@ module.exports = toObj
 // str -> obj
 function toObj (txt) {
   assert.equal(typeof txt, 'string', 'input should be a markdown string')
+  const lexer = new marked.Lexer()
   const tokens = lexer.lex(txt)
   const parsed = marked.parser(clone(tokens)).split('\n')
   const res = {}

--- a/index.js
+++ b/index.js
@@ -16,14 +16,20 @@ function toObj (txt) {
   var key = ''
 
   tokens.forEach(function (token, i) {
-    if (i === 0) assert.equal(token.type, 'heading', 'files should start with a heading')
     if (token.type === 'heading') {
       key = token.text
-      res[key] = {html: '', raw: ''}
+      res[key] = {html: '', raw: []}
       return
     }
+
+    if (!key) return
+
     res[key].html += parsed[i]
-    res[key].raw += token.text
+    res[key].raw.push(token.text)
+  })
+
+  Object.keys(res).forEach(function (key) {
+    res[key].raw = res[key].raw.join('\n')
   })
 
   return res

--- a/test/index.js
+++ b/test/index.js
@@ -26,3 +26,37 @@ test('should return a parsed obj', function (t) {
     })
   })
 })
+
+test('should handle multiple paragraphs', function (t) {
+  const fixture = path.resolve(__dirname, 'text-multi.md')
+  const markdown = fs.readFileSync(fixture, 'utf8')
+  const tree = mdjson(markdown)
+
+  t.deepEqual(tree, {
+    'first heading': {
+      html: '<p>  Hi there!</p><p>This content runs over multiple lines...</p>',
+      raw: '  Hi there!\nThis content runs over multiple lines...'
+    },
+    'second heading': {
+      html: '<p>As does this one.</p><p>With even more whitespace :O</p>',
+      raw: 'As does this one.\nWith even more whitespace :O'
+    }
+  })
+
+  t.end()
+})
+
+test('should ignore text before headings', function (t) {
+  const fixture = path.resolve(__dirname, 'text-pre-headings.md')
+  const markdown = fs.readFileSync(fixture, 'utf8')
+  const tree = mdjson(markdown)
+
+  t.deepEqual(tree, {
+    'Main Content': {
+      html: '<p>Goes here</p>',
+      raw: 'Goes here'
+    }
+  })
+
+  t.end()
+})

--- a/test/text-multi.md
+++ b/test/text-multi.md
@@ -1,0 +1,13 @@
+# first heading
+
+  Hi there!
+
+This content runs over multiple lines...
+
+## second heading
+
+As does this one.
+
+
+
+With even more whitespace :O

--- a/test/text-pre-headings.md
+++ b/test/text-pre-headings.md
@@ -1,0 +1,5 @@
+Hello World
+
+# Main Content
+
+Goes here


### PR DESCRIPTION
- Handle multiple paragraphs in input sections (previously
  whitespace between line breaks were being omitted).
- Allow text to be included before headings, for cases
  where this would be preferred.
- Recreate the lexer on each call to mdjson (this was
  causing a bug that would include previously extracted
  headings in subsequent results).

Thanks! :)
