### PR TITLE
marked -> mdast

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,25 +1,24 @@
+const html = require('mdast-html')
 const assert = require('assert')
-const marked = require('marked')
-const clone = require('clone')
+const mdast = require('mdast')
 
-module.exports = toObj
+module.exports = mdjson
 
 // map a markdown string to an object
 // with `html` and `raw` fields
 // str -> obj
-function toObj (txt) {
+function mdjson (txt) {
   assert.equal(typeof txt, 'string', 'input should be a markdown string')
-  const lexer = new marked.Lexer()
-  const tokens = lexer.lex(txt)
-  // const parsed = marked.parser(clone(tokens)).split('\n')
+  const toHtml = mdast().use(html)
+  const lexer = mdast()
+
+  const tokens = lexer.parse(txt).children
   const res = {}
   var key = ''
 
-  console.log(marked.parser(clone(tokens)).length)
-
   tokens.forEach(function (token, i) {
     if (token.type === 'heading') {
-      key = token.text
+      key = token.children[0].value
       const html = []
       html.links = true
       res[key] = {html: html, raw: []}
@@ -28,13 +27,13 @@ function toObj (txt) {
 
     if (!key) return
 
-    res[key].raw.push(token.text)
+    res[key].raw.push(lexer.stringify(token))
     res[key].html.push(token)
   })
 
   Object.keys(res).forEach(function (key) {
     res[key].raw = res[key].raw.join('\n')
-    res[key].html = marked.parser(clone(res[key].html)).trim()
+    res[key].html = toHtml.process(res[key].raw).trim()
   })
 
   return res

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
   },
   "repository": "yoshuawuyts/mdjson",
   "keywords": [
+    "json",
     "markdown",
-    "parse",
-    "json"
+    "parse"
   ],
   "license": "MIT",
   "dependencies": {
-    "clone": "^1.0.2",
-    "marked": "^0.3.3"
+    "mdast": "^0.26.0",
+    "mdast-html": "^0.1.0"
   },
   "devDependencies": {
     "istanbul": "^0.3.13",
@@ -25,7 +25,7 @@
   },
   "files": [
     "LICENSE",
-    "index.js",
-    "README.md"
+    "README.md",
+    "index.js"
   ]
 }

--- a/test/index.js
+++ b/test/index.js
@@ -34,11 +34,11 @@ test('should handle multiple paragraphs', function (t) {
 
   t.deepEqual(tree, {
     'first heading': {
-      html: '<p>  Hi there!</p>\n<p>This content runs over multiple lines...</p>',
+      html: '<p>Hi there!\nThis content runs over multiple lines...</p>',
       raw: '  Hi there!\nThis content runs over multiple lines...'
     },
     'second heading': {
-      html: '<p>As does this one.\nYup.</p>\n<p>With even more whitespace :O</p>',
+      html: '<p>As does this one.\nYup.\nWith even more whitespace :O</p>',
       raw: 'As does this one.\nYup.\nWith even more whitespace :O'
     }
   })


### PR DESCRIPTION
Closes #3. :sparkles:
## Changes
- **parser**: switch from `marked` to `mdast`
## Known issues

`mdast` trims whitespace inside nodes. Probably warrants a `semver-major` release.

ping @wooorm
