### PR TITLE
Refactor to use mdast instead of marked

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,40 +1,46 @@
 const assert = require('assert')
-const marked = require('marked')
-const clone = require('clone')
+const mdast = require('mdast')
+const html = require('mdast-html')
 
-module.exports = toObj
+module.exports = mdjson
+
+function trimRight (value) {
+  return value.replace(/\n+$/, '')
+}
 
 // map a markdown string to an object
 // with `html` and `raw` fields
 // str -> obj
-function toObj (txt) {
+function mdjson (txt) {
   assert.equal(typeof txt, 'string', 'input should be a markdown string')
-  const lexer = new marked.Lexer()
-  const tokens = lexer.lex(txt)
-  // const parsed = marked.parser(clone(tokens)).split('\n')
+  const toHtml = mdast().use(html)
+  const lexer = mdast()
+  const tokens = lexer.parse(txt).children
   const res = {}
   var key = ''
 
-  console.log(marked.parser(clone(tokens)).length)
-
   tokens.forEach(function (token, i) {
     if (token.type === 'heading') {
-      key = token.text
-      const html = []
-      html.links = true
-      res[key] = {html: html, raw: []}
+      key = token.children[0].value
+      res[key] = []
       return
     }
 
     if (!key) return
 
-    res[key].raw.push(token.text)
-    res[key].html.push(token)
+    res[key].push(token)
   })
 
   Object.keys(res).forEach(function (key) {
-    res[key].raw = res[key].raw.join('\n')
-    res[key].html = marked.parser(clone(res[key].html)).trim()
+    const node = {
+      type: 'root',
+      children: res[key]
+    }
+
+    res[key] = {
+      raw: trimRight(lexer.stringify(node)),
+      html: trimRight(toHtml.stringify(node))
+    }
   })
 
   return res

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "clone": "^1.0.2",
-    "marked": "^0.3.3"
+    "mdast": "^0.26.0",
+    "mdast-html": "^0.1.0"
   },
   "devDependencies": {
     "istanbul": "^0.3.13",

--- a/test/index.js
+++ b/test/index.js
@@ -34,12 +34,12 @@ test('should handle multiple paragraphs', function (t) {
 
   t.deepEqual(tree, {
     'first heading': {
-      html: '<p>  Hi there!</p>\n<p>This content runs over multiple lines...</p>',
-      raw: '  Hi there!\nThis content runs over multiple lines...'
+      html: '<p>Hi there!</p>\n<p>This content runs over multiple lines...</p>',
+      raw: '  Hi there!\n\nThis content runs over multiple lines...'
     },
     'second heading': {
       html: '<p>As does this one.\nYup.</p>\n<p>With even more whitespace :O</p>',
-      raw: 'As does this one.\nYup.\nWith even more whitespace :O'
+      raw: 'As does this one.\nYup.\n\nWith even more whitespace :O'
     }
   })
 


### PR DESCRIPTION
Breaking:
-   Blocks in raw output are seperated by two newlines,
  instead of one;
-   Content of HTML is trimmed.

Hope this suits your code-style! I based this on your commit, but reverted some changes in the tests!

Closes GH-3.
