### PR TITLE
standardize

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,4 +49,3 @@ function mdjson (txt) {
 function trimRight (value) {
   return value.replace(/\n+$/, '')
 }
-


### PR DESCRIPTION
Extra line at the end of `index.js`, I think eslint got better at detecting this recently.
